### PR TITLE
Pass the requestBodyAllowedMethods variable to use the delete method with request body.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,21 +75,21 @@ function OpenApiEnforcerMiddleware (definition, options) {
   if (typeof general.reqOperationProperty !== 'string') throw Error('Configuration option "reqOperationProperty" must be a string. Received: ' + general.reqOperationProperty)
   if (typeof general.xController !== 'string') throw Error('Configuration option "xController" must be a string. Received: ' + general.xController)
   if (typeof general.xOperation !== 'string') throw Error('Configuration option "xOperation" must be a string. Received: ' + general.xOperation)
-  this.options = general;
+  this.options = general
 
-  let internalOptions = { requestBodyAllowedMethods: options.requestBodyAllowedMethods || null };
+  let internalOptions = { requestBodyAllowedMethods: options.requestBodyAllowedMethods || null }
 
   // update allowOtherQueryParameters to allow the mockQuery parameter
-  if (general.allowOtherQueryParameters === false) general.allowOtherQueryParameters = [];
-  if (Array.isArray(general.allowOtherQueryParameters)) general.allowOtherQueryParameters.push(general.mockQuery);
+  if (general.allowOtherQueryParameters === false) general.allowOtherQueryParameters = []
+  if (Array.isArray(general.allowOtherQueryParameters)) general.allowOtherQueryParameters.push(general.mockQuery)
 
   // wait for the definition to be built
   this.promise = Enforcer(definition, { fullResult: true, internalOptions: internalOptions })
     .then(result => {
-      const [ openapi, exception, warning ] = result;
-      if (exception) throw Error(exception.toString());
-      if (warning) console.warn(warning);
-      return openapi;
+      const [ openapi, exception, warning ] = result
+      if (exception) throw Error(exception.toString())
+      if (warning) console.warn(warning)
+      return openapi
     })
 }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,21 @@ const ENFORCER_HEADER = 'x-openapi-enforcer'
 
 module.exports = OpenApiEnforcerMiddleware
 
+/**
+ * Create an OpenApiEnforcerMiddleware.
+ * @param {string, object} definition
+ * @param {object} [options]
+ * @param {array} [options.allowOtherQueryParameters]
+ * @param {string} [options.mockHeader]
+ * @param {string} [options.mockQuery]
+ * @param {string} [options.reqMockProperty]
+ * @param {string} [options.reqOpenApiProperty]
+ * @param {string} [options.reqOperationProperty]
+ * @param {string} [options.xController]
+ * @param {string} [options.xOperation]
+ * @param {object} [options.requestBodyAllowedMethods]
+ * @returns {Promise<OpenApiEnforcer>}
+ */
 function OpenApiEnforcerMiddleware (definition, options) {
   if (!(this instanceof OpenApiEnforcerMiddleware)) return new OpenApiEnforcerMiddleware(definition, options)
 
@@ -60,19 +75,21 @@ function OpenApiEnforcerMiddleware (definition, options) {
   if (typeof general.reqOperationProperty !== 'string') throw Error('Configuration option "reqOperationProperty" must be a string. Received: ' + general.reqOperationProperty)
   if (typeof general.xController !== 'string') throw Error('Configuration option "xController" must be a string. Received: ' + general.xController)
   if (typeof general.xOperation !== 'string') throw Error('Configuration option "xOperation" must be a string. Received: ' + general.xOperation)
-  this.options = general
+  this.options = general;
+
+  let internalOptions = { requestBodyAllowedMethods: options.requestBodyAllowedMethods || null };
 
   // update allowOtherQueryParameters to allow the mockQuery parameter
-  if (general.allowOtherQueryParameters === false) general.allowOtherQueryParameters = []
-  if (Array.isArray(general.allowOtherQueryParameters)) general.allowOtherQueryParameters.push(general.mockQuery)
+  if (general.allowOtherQueryParameters === false) general.allowOtherQueryParameters = [];
+  if (Array.isArray(general.allowOtherQueryParameters)) general.allowOtherQueryParameters.push(general.mockQuery);
 
   // wait for the definition to be built
-  this.promise = Enforcer(definition, { fullResult: true })
+  this.promise = Enforcer(definition, { fullResult: true, internalOptions: internalOptions })
     .then(result => {
-      const [ openapi, exception, warning ] = result
-      if (exception) throw Error(exception.toString())
-      if (warning) console.warn(warning)
-      return openapi
+      const [ openapi, exception, warning ] = result;
+      if (exception) throw Error(exception.toString());
+      if (warning) console.warn(warning);
+      return openapi;
     })
 }
 


### PR DESCRIPTION
Hello!
We at the company use your libraries: openapi-enforcer and openapi-enforcer-middleware.
We need the ability to pass parameters in the body of the delete request.
To solve this problem, I implemented the transfer of the requestBodyAllowedMethods parameter in the config variable.
Please confirm this pull request
Thanks!