### PR TITLE
add response.schema.type check

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ OpenApiEnforcerMiddleware.prototype.middleware = function () {
 
             Object.keys(response.headers).forEach(header => res.set(header, extractValue(response.headers[header])))
             if (response.hasOwnProperty('body')) {
-              const sendObject = response.schema
+              const sendObject = response.schema && response.schema.type
                 ? ['array', 'object'].indexOf(response.schema.type) !== -1
                 : typeof response.body === 'object'
               res.send(sendObject ? response.body : String(response.body))


### PR DESCRIPTION
I am using `allOf` rule to merge a particular response schema with an generic api-level schema. 
OAS 3:

```yaml
components:
  schemas:
    SuccessStatusCode:
      type: object
      properties:
        statusCode:
          type: integer
          minimum: 200
          maximum: 399
      required:
        - statusCode

...

      responses:
        200:
          description: OK
          content:
            application/json:
              schema:
                allOf:
                  - type: object
                    properties:
                      id:
                        type: integer
                      token:
                        type: string
                    required:
                      - id
                      - token
                  - $ref: "#/components/schemas/SuccessStatusCode"
```
The controller for this endpoint should produce a response body like
```json
{
  "id": 1,
  "token": "something",
  "statusCode": 200
}
```
The issue I have encountered is that openapi-enforcer-middleware checks whether `response.schema.type` has value of `array` or `object`. However, when using `allOf` there is no `response.schema.type`. Instead, each schema nested inside the `allOf` property has a `type`.
<img width="1331" alt="Screen Shot 2019-05-27 at 11 14 39 PM" src="https://user-images.githubusercontent.com/8955144/58448978-ab31c380-80d7-11e9-97b4-acc0feb94ebe.png">

The current code produces a response like `[Object object]`.

A possible fix is to add the extra `response.schema.type` check in the ternary condition (shown in this PR).
