### PR TITLE
Add support for async error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,10 @@ OpenApiEnforcerMiddleware.prototype.controllers = function (controllersTarget, .
         if (controller) {
           res.set(ENFORCER_HEADER, 'controller')
           debug.controllers('executing controller')
-          controller(req, res, next)
+          // return controller result for async error handling in express 5 and router 2.x
+          // https://github.com/expressjs/express/releases/tag/5.0.0-alpha.7
+          // https://github.com/pillarjs/router/tree/2.0#middleware
+          return controller(req, res, next)
         } else {
           next()
         }


### PR DESCRIPTION
In Express 5.x and via [async-express-decorator](https://github.com/mikhail-dezhurko/async-express-decorator) it is possible to handle errors thrown in promises without wrapping them in a try/catch block.

Returning the result of the `controller()` invocation seems to be all that is needed.